### PR TITLE
python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# py3
+.eggs

--- a/bmi/api.py
+++ b/bmi/api.py
@@ -1,9 +1,11 @@
 from abc import abstractmethod
 from abc import ABCMeta
 
+from six import with_metaclass
 
-class IBmi(object):
-    __metaclass__ = ABCMeta
+
+# class IBmi(object, metaclass=ABCMeta) can be written
+class IBmi(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def initialize(self, configfile=None):
@@ -145,4 +147,3 @@ class IBmi(object):
         Lookup the type,rank and shape of a compound field
         """
         pass
-


### PR DESCRIPTION
Should fix tests. Metaprogramming was used which was changed in python 3. http://python-3-patterns-idioms-test.readthedocs.org/en/latest/Metaprogramming.html